### PR TITLE
Adds yo as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "yeoman-generator": "~0.12.0"
   },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
+  },
   "devDependencies": {
     "mocha": "~1.9.0"
   },


### PR DESCRIPTION
As `yo` specifies `grunt-cli` and `bower` as peerDependencies, this should allow a `npm install -g generator-h5bp` to install all three of them globally.
