### PR TITLE
Inherit the base Yeoman generator (Fix #11)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var util = require('util');
+var yeoman = require('yeoman-generator');
+
 var Generator = module.exports = function () {
 	var cb = this.async();
 	var ignores = [
@@ -35,5 +38,7 @@ var Generator = module.exports = function () {
 		cb();
 	}.bind(this));
 };
+
+util.inherits(Generator, yeoman.generators.Base);
 
 Generator.name = 'HTML5 Boilerplate';


### PR DESCRIPTION
Yeoman-generator 0.14 removed a fix allowing to register a single function as a generator and extending automatically the base generator. This was error prone and was not really obvious. (FWIW the bug happening right now have nothing to do with yo@1.0.5, its really related to the generator system 0.14 release)
