### PR TITLE
Inline JSHint configs must be comma-separated

### DIFF
--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -1,4 +1,4 @@
-/*global describe beforeEach it */
+/*global describe, beforeEach, it */
 'use strict';
 var path = require('path');
 var helpers = require('yeoman-generator').test;


### PR DESCRIPTION
According to http://www.jshint.com/docs/ the variable names after a inline `global` statement must be comma-seperated.

> these comments start either with jshint or global and are followed by a comma-separated list of values.
