### PR TITLE
`.jshintrc`: remove unnecessary options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,5 @@
 {
 	"node": true,
-	"es5": true,
 	"esnext": true,
 	"bitwise": true,
 	"camelcase": true,
@@ -15,7 +14,5 @@
 	"regexp": true,
 	"undef": true,
 	"unused": true,
-	"strict": true,
-	"trailing": true,
-	"smarttabs": true
+	"strict": true
 }


### PR DESCRIPTION
- The `es5` option is turned on by default since JSHint v2.
- The options `trailing` and `smarttabs` are deprecated since JSHint v2.5.
